### PR TITLE
user 도메인 구성

### DIFF
--- a/src/main/java/com/roomfit/be/user/User.java
+++ b/src/main/java/com/roomfit/be/user/User.java
@@ -1,0 +1,34 @@
+    package com.roomfit.be.user;
+
+import com.roomfit.be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name="users")
+@Getter
+@NoArgsConstructor
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String nickname;
+    private String email;
+    private String password;
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    public User(String nickname, String email, String password, UserRole role) {
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+    }
+
+    public static User createAdmin(String nickname, String email, String password){
+        return new User(nickname, email, password, UserRole.ADMIN);
+    }
+    public static User createUser(String nickname, String email, String password){
+        return new User(nickname, email, password, UserRole.DEFAULT);
+    }
+}

--- a/src/main/java/com/roomfit/be/user/UserController.java
+++ b/src/main/java/com/roomfit/be/user/UserController.java
@@ -1,0 +1,29 @@
+package com.roomfit.be.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("")
+    public UserDTO.Response create(@RequestBody() UserDTO.Create request){
+        return userService.create(request);
+    }
+
+    @GetMapping("")
+    public List<UserDTO.Response> readAll(){
+        return userService.readAll();
+    }
+
+    @GetMapping("/{user_id}")
+    public UserDTO.Response readById(@PathVariable("user_id") Long id) {
+        return userService.readById(id);
+    }
+
+}

--- a/src/main/java/com/roomfit/be/user/UserDTO.java
+++ b/src/main/java/com/roomfit/be/user/UserDTO.java
@@ -1,0 +1,39 @@
+package com.roomfit.be.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class UserDTO {
+    /**
+     * when userDTO deserialize to User Entity, the password in User DTO should be encrypted.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Create{
+        private String nickname;
+        private String email;
+        private String password;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response{
+        private Long id;
+        private String nickname;
+        private String email;
+        private String password;
+        public static Response of(User user) {
+            return Response.builder()
+                    .id(user.getId())
+                    .nickname(user.getNickname())
+                    .email(user.getEmail())
+                    .password(user.getPassword())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/roomfit/be/user/UserNotFoundException.java
+++ b/src/main/java/com/roomfit/be/user/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.roomfit.be.user;
+
+public class UserNotFoundException extends RuntimeException{
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/roomfit/be/user/UserRepository.java
+++ b/src/main/java/com/roomfit/be/user/UserRepository.java
@@ -1,0 +1,6 @@
+package com.roomfit.be.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/roomfit/be/user/UserRole.java
+++ b/src/main/java/com/roomfit/be/user/UserRole.java
@@ -1,0 +1,6 @@
+package com.roomfit.be.user;
+
+public enum UserRole {
+    DEFAULT,
+    ADMIN
+}

--- a/src/main/java/com/roomfit/be/user/UserService.java
+++ b/src/main/java/com/roomfit/be/user/UserService.java
@@ -1,0 +1,9 @@
+package com.roomfit.be.user;
+
+import java.util.List;
+
+public interface UserService {
+    UserDTO.Response create(UserDTO.Create request);
+    UserDTO.Response readById(Long id);
+    List<UserDTO.Response> readAll();
+}

--- a/src/main/java/com/roomfit/be/user/UserServiceImpl.java
+++ b/src/main/java/com/roomfit/be/user/UserServiceImpl.java
@@ -1,0 +1,37 @@
+package com.roomfit.be.user;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService{
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public UserDTO.Response create(UserDTO.Create request) {
+        User newUser = User.createUser(request.getNickname(), request.getEmail(), request.getPassword());
+        User savedUser = userRepository.save(newUser);
+
+        return UserDTO.Response.of(savedUser);
+    }
+
+    @Override
+    public UserDTO.Response readById(Long id) {
+        User foundUser =  userRepository.findById(id)
+                .orElseThrow(()-> new UserNotFoundException(""));
+
+        return UserDTO.Response.of(foundUser);
+    }
+    public List<UserDTO.Response> readAll() {
+        List<User> foundUser = userRepository.findAll();
+
+        return foundUser.stream()
+                .map(UserDTO.Response::of)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 🐛 연결 이슈
- #6 

## ✨ 기능 설명

- [x] 회원가입
- [x] 유저 조회
- [x] 유저 프로필 조회

## ❓ 왜 필요한가요?

회원 기반의 서비스 제공

## 📖 어떻게 제작했나요?
해당 도메인은 JPA를 활용하여 기본적으로 구성하였으며, 아래와 같은 ERD 구조를 참조하여 만들었습니다.

<img width="334" alt="image" src="https://github.com/user-attachments/assets/de62e078-7316-4bff-837e-e3c0cbd7ef4d" />

현재 조회에 대한 성능 개선은 따로 진행하지 않았고, 추후 다른 도메인이 추가됨에 따라 성능을 확인한 후에 추가적인 개선을 진행할 예정이다.