### PR TITLE
인증 로직 구현 - JWT 기반 로그인 인증 로직 추가

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           echo "${{ secrets.APPLICATION_YML }}" | base64 --decode > src/main/resources/application.yml
           echo "${{ secrets.APPLICATION_LOCAL_YML }}" | base64 --decode > src/main/resources/application-local.yml
+          echo "${{ secrets.APPLICATION_JWT_YML }}" | base64 --decode > src/main/resources/application-jwt.yml
 
 # 3. Gradle 빌드 (jar 파일 생성)
       - name: Build jar file
@@ -42,6 +43,8 @@ jobs:
         run: |
           echo "${{ secrets.APPLICATION_YML }}" | base64 --decode > src/main/resources/application.yml
           echo "${{ secrets.APPLICATION_LOCAL_YML }}" | base64 --decode > src/main/resources/application-local.yml
+          echo "${{ secrets.APPLICATION_JWT_YML }}" | base64 --decode > src/main/resources/application-jwt.yml
+          
           ls -l src/main/resources/
 
       # 6. Docker 이미지 빌드

--- a/build.gradle
+++ b/build.gradle
@@ -61,11 +61,17 @@ dependencies {
     //Redis
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     //Email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
+    //CONFIG
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/roomfit/be/auth/application/AuthService.java
+++ b/src/main/java/com/roomfit/be/auth/application/AuthService.java
@@ -1,6 +1,9 @@
 package com.roomfit.be.auth.application;
 
+import com.roomfit.be.auth.application.dto.AuthDTO;
+
 public interface AuthService {
     void generateVerificationCode(String sessionId, String email);
     boolean verifyVerificationCode(String sessionId, String code);
+    AuthDTO.LoginResponse authenticate(AuthDTO.Login request);
 }

--- a/src/main/java/com/roomfit/be/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/roomfit/be/auth/application/AuthServiceImpl.java
@@ -1,8 +1,12 @@
 package com.roomfit.be.auth.application;
 
+import com.roomfit.be.auth.application.dto.AuthDTO;
 import com.roomfit.be.email.EmailSendEvent;
 import com.roomfit.be.redis.application.ReactiveRedisService;
+import com.roomfit.be.user.application.UserService;
+import com.roomfit.be.user.application.dto.UserDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -11,9 +15,26 @@ import java.security.SecureRandom;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthServiceImpl implements AuthService{
     private final ApplicationEventPublisher applicationEventPublisher;
     private final ReactiveRedisService reactiveRedisService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
+    @Override
+    public AuthDTO.LoginResponse authenticate(AuthDTO.Login request) {
+        UserDTO.Response foundUser = userService.readByEmail(request.getEmail());
+        if(!request.getPassword().equals(foundUser.getPassword()))
+             throw new RuntimeException("Not found");
+
+        String accessToken = jwtTokenProvider.generateAccessToken(request.getEmail());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(request.getEmail());
+
+        reactiveRedisService.saveWithTTL(request.getEmail(), refreshToken, 300)
+                .subscribe();
+
+        return AuthDTO.LoginResponse.of(accessToken, refreshToken);
+    }
 
     @Async("taskExecutor")
     @Override
@@ -37,6 +58,7 @@ public class AuthServiceImpl implements AuthService{
         String savedCode = (String) reactiveRedisService.get(sessionId).block(); // block()을 사용하여 동기적으로 값 가져오기
         return savedCode != null && savedCode.equals(code);
     }
+
 
     private String generateRandomCode(int length) {
         SecureRandom random = new SecureRandom();

--- a/src/main/java/com/roomfit/be/auth/application/JwtProperties.java
+++ b/src/main/java/com/roomfit/be/auth/application/JwtProperties.java
@@ -1,0 +1,13 @@
+package com.roomfit.be.auth.application;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+@Data
+public class JwtProperties {
+    private String secretKey;  // 비밀 키
+    private long accessTokenExpirationTime;  // Access Token 유효 기간
+    private long refreshTokenExpirationTime;
+}

--- a/src/main/java/com/roomfit/be/auth/application/JwtTokenProvider.java
+++ b/src/main/java/com/roomfit/be/auth/application/JwtTokenProvider.java
@@ -1,0 +1,65 @@
+package com.roomfit.be.auth.application;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;  // JwtProperties를 주입받아서 사용
+
+    // Access Token 생성
+    public String generateAccessToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)  // 사용자 이름을 subject로 설정
+                .setIssuedAt(new Date())  // 발급 시간
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getAccessTokenExpirationTime()))  // 만료 시간
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())  // 서명 (비밀 키 사용)
+                .compact();  // JWT 생성
+    }
+
+    // Refresh Token 생성
+    public String generateRefreshToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getRefreshTokenExpirationTime()))
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                .compact();
+    }
+
+    // JWT에서 Claims(사용자 정보 등) 추출
+    public Claims getClaimsFromToken(String token) {
+        return Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretKey())  // 서명 검증을 위한 키 설정
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // JWT에서 사용자 이름(Subject)을 추출
+    public String getUsernameFromToken(String token) {
+        Claims claims = getClaimsFromToken(token);
+        return claims.getSubject();  // JWT에서 Subject는 보통 사용자 정보입니다.
+    }
+
+    // JWT가 만료되었는지 여부 확인
+    public boolean isTokenExpired(String token) {
+        Date expiration = getClaimsFromToken(token).getExpiration();
+        return expiration.before(new Date());  // 현재 시간보다 만료 시간이 이전이면 expired
+    }
+
+    // JWT 토큰 검증 (서명 및 만료 시간 확인)
+    public boolean validateToken(String token) {
+        try {
+            return !isTokenExpired(token);  // 만료된 토큰은 유효하지 않음
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/roomfit/be/auth/application/dto/AuthDTO.java
+++ b/src/main/java/com/roomfit/be/auth/application/dto/AuthDTO.java
@@ -1,0 +1,31 @@
+package com.roomfit.be.auth.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class AuthDTO {
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Login{
+        String email;
+        String password;
+    }
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class LoginResponse{
+        String accessToken;
+        String refreshToken;
+        public static LoginResponse of(String accessToken, String refreshToken){
+            return LoginResponse.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/roomfit/be/auth/presentation/AuthController.java
+++ b/src/main/java/com/roomfit/be/auth/presentation/AuthController.java
@@ -1,6 +1,7 @@
 package com.roomfit.be.auth.presentation;
 
 import com.roomfit.be.auth.application.AuthService;
+import com.roomfit.be.auth.application.dto.AuthDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,9 @@ public class AuthController {
 
     private final AuthService authService;
     @PostMapping("/login")
-    void login() {
+    AuthDTO.LoginResponse login(@RequestBody AuthDTO.Login request) {
+
+        return authService.authenticate(request);
     }
 
     /**
@@ -25,10 +28,8 @@ public class AuthController {
      */
     @PostMapping("/code")
     String sendVerificationCode(@RequestBody String email, HttpServletRequest request) {
-        log.info(email);
         HttpSession session = request.getSession();
         String sessionId = session.getId();
-        log.info(session.getId());
 
         authService.generateVerificationCode(sessionId, email);
         return "successfully";

--- a/src/main/java/com/roomfit/be/global/config/JwtConfig.java
+++ b/src/main/java/com/roomfit/be/global/config/JwtConfig.java
@@ -1,0 +1,10 @@
+package com.roomfit.be.global.config;
+
+import com.roomfit.be.auth.application.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties.class)
+public class JwtConfig {
+}

--- a/src/main/java/com/roomfit/be/user/application/UserService.java
+++ b/src/main/java/com/roomfit/be/user/application/UserService.java
@@ -7,5 +7,6 @@ import java.util.List;
 public interface UserService {
     UserDTO.Response create(UserDTO.Create request);
     UserDTO.Response readById(Long id);
+    UserDTO.Response readByEmail(String email);
     List<UserDTO.Response> readAll();
 }

--- a/src/main/java/com/roomfit/be/user/application/UserServiceImpl.java
+++ b/src/main/java/com/roomfit/be/user/application/UserServiceImpl.java
@@ -31,6 +31,15 @@ public class UserServiceImpl implements UserService{
 
         return UserDTO.Response.of(foundUser);
     }
+
+    @Override
+    public UserDTO.Response readByEmail(String email){
+        User foundUser =  userRepository.findByEmail(email)
+                .orElseThrow(()-> new UserNotFoundException(""));
+
+        return UserDTO.Response.of(foundUser);
+    }
+
     public List<UserDTO.Response> readAll() {
         List<User> foundUser = userRepository.findAll();
 

--- a/src/main/java/com/roomfit/be/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/roomfit/be/user/infrastructure/UserRepository.java
@@ -3,5 +3,8 @@ package com.roomfit.be.user.infrastructure;
 import com.roomfit.be.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
## 🐛 연결 된 이슈
- #19 

## 구현 내용
- JwtProvider 를 통해서 accessToken, refreshToken 생성 로직 구현
- JwtProperties 를 통해 컴파일 라인에서 jwt profile 내의 환경 변수를 주입 받도록 구성
- refreshToken 을 redis로 저장하여 이를 저장 하여, 추후 `token rotation` 기법 적용을 가능 하도록함.

## 추후 고려할 사항
- 성능 관련 부분 동기, 비동기 처리
- refresh, access token 의 알고리즘 로직 및 secret 따로 가용
- 병목 지점 테스트
- token rotation 기법 적용
- 인가 라인을 추가

## 결과
![image](https://github.com/user-attachments/assets/0c97f7c0-02a3-4c0f-9c8c-555aeae75190)

* 총 10 번의 요청에서 `현재 평균 응답 15ms` 