### PR TITLE
사용자, 설문, 채팅, 인증 API Swagger 명세 개선

### DIFF
--- a/src/main/java/com/roomfit/be/auth/application/resolver/AuthCheckResolver.java
+++ b/src/main/java/com/roomfit/be/auth/application/resolver/AuthCheckResolver.java
@@ -30,10 +30,10 @@ public class AuthCheckResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String authorizationHeader = request.getHeader("Authorization");
-
+        if(authorizationHeader.isEmpty()) throw new RuntimeException("");
         // Extract the token from the Authorization header
         String token = jwtTokenExtractor.extractTokenFromHeader(authorizationHeader);
-
+        if(token.isEmpty()) throw new RuntimeException("");
         // Extract the role and other user details from the token
         UserDetails userDetails = jwtTokenProvider.extractUserDetailFromToken(token);
 

--- a/src/main/java/com/roomfit/be/auth/presentation/AuthController.java
+++ b/src/main/java/com/roomfit/be/auth/presentation/AuthController.java
@@ -4,6 +4,7 @@ import com.roomfit.be.auth.application.AuthService;
 import com.roomfit.be.auth.application.dto.AuthDTO;
 import com.roomfit.be.global.response.CommonResponse;
 import com.roomfit.be.global.response.ResponseFactory;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
-
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -27,6 +27,10 @@ public class AuthController {
     /**
      * 로그인
      */
+    @Operation(
+            summary = "로그인",
+            description = "사용자가 제공한 로그인 정보로 인증을 수행합니다."
+    )
     @PostMapping("/login")
     public ResponseEntity<CommonResponse<AuthDTO.LoginResponse>> login(
             @RequestBody @Parameter(description = "로그인 정보") AuthDTO.Login request) {
@@ -40,6 +44,10 @@ public class AuthController {
     /**
      * 인증 코드 전송
      */
+    @Operation(
+            summary = "인증 코드 전송",
+            description = "이메일로 인증 코드를 전송합니다."
+    )
     @PostMapping("/code")
     public ResponseEntity<CommonResponse<String>> sendVerificationCode(
             @RequestBody @Parameter(description = "이메일") AuthDTO.SendCodeRequest request) {
@@ -54,6 +62,10 @@ public class AuthController {
     /**
      * 인증 코드 검증
      */
+    @Operation(
+            summary = "인증 코드 검증",
+            description = "사용자가 제공한 인증 코드가 유효한지 검증합니다."
+    )
     @PostMapping("/verify")
     public ResponseEntity<CommonResponse<Boolean>> verifyVerificationCode(
             @RequestBody @Parameter(description = "인증 코드 요청 정보") AuthDTO.VerifyCodeRequest request) {

--- a/src/main/java/com/roomfit/be/chat/presentation/ChatController.java
+++ b/src/main/java/com/roomfit/be/chat/presentation/ChatController.java
@@ -6,12 +6,13 @@ import com.roomfit.be.chat.application.dto.ChatRoomDTO;
 import com.roomfit.be.global.annontation.AuthCheck;
 import com.roomfit.be.global.response.CommonResponse;
 import com.roomfit.be.global.response.ResponseFactory;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
 @RestController
 @RequestMapping("/api/v1/chats")
 @RequiredArgsConstructor
@@ -21,11 +22,13 @@ public class ChatController {
     /**
      * 채팅방 생성
      */
+    @Operation(summary = "채팅방 만들기", description = "채팅방에 참여합니다.")
+    @SecurityRequirement(name = "bearerAuth")
     @AuthCheck()
     @PostMapping("")
     public ResponseEntity<CommonResponse<ChatRoomDTO.Response>> createChatRoom(
-            UserDetails userDetails,
-            @RequestBody ChatRoomDTO.Create request) {
+            @Parameter(hidden = true) UserDetails userDetails,
+            @Parameter(description = "채팅방 생성 요청 객체", required = true) @RequestBody ChatRoomDTO.Create request) {
 
         ChatRoomDTO.Response response = chatService.createRoom(userDetails.getId(), request);
         CommonResponse<ChatRoomDTO.Response> commonResponse = ResponseFactory.success(response, "채팅방 생성 성공");
@@ -37,11 +40,13 @@ public class ChatController {
     /**
      * 채팅방 참여
      */
+    @Operation(summary = "채팅방 참여", description = "채팅방에 참여합니다.")
+    @SecurityRequirement(name = "bearerAuth")
     @AuthCheck()
     @PostMapping("/{chat_id}/join")
     public ResponseEntity<CommonResponse<ChatRoomDTO.Response>> enterChatRoom(
-            UserDetails userDetails,
-            @Parameter(description = "채팅방 ID") @PathVariable("chat_id") Long chatId) {
+            @Parameter(hidden = true) UserDetails userDetails,
+            @Parameter(description = "채팅방 ID", example = "1") @PathVariable("chat_id") Long chatId) {
 
         ChatRoomDTO.Response response = chatService.enterRoom(userDetails.getId(), chatId);
         CommonResponse<ChatRoomDTO.Response> commonResponse = ResponseFactory.success(response, "채팅방 참여 성공");
@@ -53,11 +58,13 @@ public class ChatController {
     /**
      * 채팅방 퇴장
      */
+    @Operation(summary = "채팅방 퇴장", description = "채팅방에서 퇴장합니다.")
+    @SecurityRequirement(name = "bearerAuth")
     @AuthCheck()
     @PostMapping("/{chat_id}/leave")
     public ResponseEntity<CommonResponse<String>> leaveChatRoom(
-            UserDetails userDetails,
-            @Parameter(description = "채팅방 ID") @PathVariable("chat_id") Long chatId) {
+            @Parameter(hidden = true) UserDetails userDetails,
+            @Parameter(description = "채팅방 ID", example = "1") @PathVariable("chat_id") Long chatId) {
 
         // 채팅방 퇴장 로직 (실제로는 로직 추가 필요)
         CommonResponse<String> commonResponse = ResponseFactory.success("채팅방 퇴장 성공");
@@ -69,9 +76,12 @@ public class ChatController {
     /**
      * 채팅방 메시지 조회
      */
+    @Operation(summary = "채팅방 메시지 조회", description = "채팅방 내 메시지를 조회합니다.")
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/{chat_id}/messages")
     public ResponseEntity<CommonResponse<String>> readMessagesByChatId(
-            @PathVariable("chat_id") Long chatId) {
+            @Parameter(description = "채팅방 ID", example = "1") @PathVariable("chat_id") Long chatId) {
+
         // 메시지 조회 로직 (실제로는 로직 추가 필요)
         CommonResponse<String> commonResponse = ResponseFactory.success("메시지 조회 성공");
         return ResponseEntity

--- a/src/main/java/com/roomfit/be/global/config/SwaggerConfig.java
+++ b/src/main/java/com/roomfit/be/global/config/SwaggerConfig.java
@@ -1,21 +1,34 @@
 package com.roomfit.be.global.config;
 
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         Info info = new Info()
-                .version("0.0.1")
+                .version("0.0.2")
                 .title("Room-fit Project swagger")
                 .description("룸핏 프로젝트에 대한 Swagger");
 
+
         return new OpenAPI()
-                .info(info);
+                .info(info)
+                .components(new Components())
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
     }
 }

--- a/src/main/java/com/roomfit/be/survey/presentation/SurveyController.java
+++ b/src/main/java/com/roomfit/be/survey/presentation/SurveyController.java
@@ -6,8 +6,7 @@ import com.roomfit.be.survey.application.SurveyService;
 import com.roomfit.be.survey.application.dto.QuestionnaireDTO;
 import com.roomfit.be.survey.application.dto.ReplyDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,13 +21,13 @@ public class SurveyController {
     /**
      * 설문지 생성
      */
-    @Operation(summary = "새로운 설문지 생성", description = "이 API는 새로운 설문지를 생성합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "설문지 생성 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청")
-    })
+    @Operation(
+            summary = "새로운 설문지 생성",
+            description = "제공된 요청 객체를 기반으로 새로운 설문지를 생성합니다."
+    )
     @PostMapping("")
-    public ResponseEntity<CommonResponse<QuestionnaireDTO.Response>> createQuestionnaire(@RequestBody QuestionnaireDTO.Create request) {
+    public ResponseEntity<CommonResponse<QuestionnaireDTO.Response>> createQuestionnaire(
+            @RequestBody @Parameter(description = "설문지 생성 요청 객체", required = true) QuestionnaireDTO.Create request) {
         QuestionnaireDTO.Response response = surveyService.createQuestionnaire(request);
         CommonResponse<QuestionnaireDTO.Response> commonResponse = ResponseFactory.success(response, "설문지 생성 성공");
         return ResponseEntity
@@ -39,11 +38,10 @@ public class SurveyController {
     /**
      * 최신 설문지 조회
      */
-    @Operation(summary = "최신 설문지 조회", description = "이 API는 최신 설문지를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "최신 설문지 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "설문지가 존재하지 않음")
-    })
+    @Operation(
+            summary = "최신 설문지 조회",
+            description = "가장 최근에 생성된 설문지를 조회합니다."
+    )
     @GetMapping("")
     public ResponseEntity<CommonResponse<QuestionnaireDTO.Response>> readQuestionnaire() {
         QuestionnaireDTO.Response response = surveyService.readLatestQuestionnaire();
@@ -56,13 +54,13 @@ public class SurveyController {
     /**
      * 설문 답변 생성
      */
-    @Operation(summary = "설문 답변 생성", description = "이 API는 설문에 대한 답변을 생성합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "설문 답변 생성 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청")
-    })
+    @Operation(
+            summary = "설문지에 대한 답변 생성",
+            description = "제공된 요청 객체를 기반으로 설문지에 대한 답변을 생성합니다."
+    )
     @PostMapping("/reply")
-    public ResponseEntity<CommonResponse<QuestionnaireDTO.Response>> createReply(@RequestBody ReplyDTO.Create request) {
+    public ResponseEntity<CommonResponse<QuestionnaireDTO.Response>> createReply(
+            @RequestBody @Parameter(description = "설문 답변 생성 요청 객체", required = true) ReplyDTO.Create request) {
         QuestionnaireDTO.Response response = surveyService.createReply(request);
         CommonResponse<QuestionnaireDTO.Response> commonResponse = ResponseFactory.success(response, "설문 답변 생성 성공");
         return ResponseEntity
@@ -73,13 +71,13 @@ public class SurveyController {
     /**
      * 사용자별 설문 답변 조회
      */
-    @Operation(summary = "사용자별 설문 답변 조회", description = "이 API는 특정 사용자의 설문 답변을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용자별 설문 답변 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "사용자가 존재하지 않음")
-    })
+    @Operation(
+            summary = "특정 사용자의 설문 답변 조회",
+            description = "사용자 ID를 기반으로 해당 사용자의 설문지에 대한 답변을 조회합니다."
+    )
     @GetMapping("/reply")
-    public ResponseEntity<CommonResponse<QuestionnaireDTO.Response>> readReply(@RequestParam("user_id") Long id) {
+    public ResponseEntity<CommonResponse<QuestionnaireDTO.Response>> readReply(
+            @RequestParam("user_id") @Parameter(description = "조회하려는 사용자 ID", required = true, example = "123") Long id) {
         QuestionnaireDTO.Response response = surveyService.readReplyByUserId(id);
         CommonResponse<QuestionnaireDTO.Response> commonResponse = ResponseFactory.success(response, "사용자별 설문 답변 조회 성공");
         return ResponseEntity

--- a/src/main/java/com/roomfit/be/user/presentation/UserController.java
+++ b/src/main/java/com/roomfit/be/user/presentation/UserController.java
@@ -4,6 +4,7 @@ import com.roomfit.be.global.response.CommonResponse;
 import com.roomfit.be.global.response.ResponseFactory;
 import com.roomfit.be.user.application.UserService;
 import com.roomfit.be.user.application.dto.UserDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,10 @@ public class UserController {
     /**
      * 사용자 생성
      */
+    @Operation(
+            summary = "사용자 생성",
+            description = "새로운 사용자를 생성합니다."
+    )
     @PostMapping("")
     public ResponseEntity<CommonResponse<UserDTO.Response>> create(
             @RequestBody UserDTO.Create request) {
@@ -33,6 +38,10 @@ public class UserController {
     /**
      * 모든 사용자 조회
      */
+    @Operation(
+            summary = "모든 사용자 조회",
+            description = "시스템에 등록된 모든 사용자를 조회합니다."
+    )
     @GetMapping("")
     public ResponseEntity<CommonResponse<List<UserDTO.Response>>> readAll() {
         List<UserDTO.Response> response = userService.readAll();
@@ -45,6 +54,10 @@ public class UserController {
     /**
      * 사용자 ID로 조회
      */
+    @Operation(
+            summary = "사용자 ID로 조회",
+            description = "특정 사용자의 ID로 사용자를 조회합니다."
+    )
     @GetMapping("/{user_id}")
     public ResponseEntity<CommonResponse<UserDTO.Response>> readById(
             @PathVariable("user_id") Long id) {


### PR DESCRIPTION
## 🐛 연결 된 이슈
- #29 
- #30 


## 🐞 해결 된 버그 사항
- #30 
위에서 발생한 inner class 내의 Request, Response DTO 의 Example Schema 를 형성 하지 못하는 오류가 발생 했고, 이를 yml 에 `use-fqn: true` 옵션을 추가함으로써, 이를 해결하였습니다.

## 🌟  내용
- 사용자, 설문, 채팅, 인증 기능에 해당하는 API 의 명세를 고도화
- 인증에 대한 Header 처리를 추가하여 명세의 일관성을 유지