### PR TITLE
채팅방 생성시, 기숙사 및 설명에 대한 필드 추가

### DIFF
--- a/src/main/java/com/roomfit/be/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/roomfit/be/chat/application/ChatRoomServiceImpl.java
@@ -53,7 +53,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     private ChatRoom createGroupRoom(ChatRoomDTO.Create request){
-        return ChatRoom.createGroupRoom(request.getName(), request.getMaxQuota());
+        return ChatRoom.createGroupRoom(request.getName(), request.getDescription(), request.getDormitory(), request.getMaxQuota());
     }
     private ChatRoom createPrivateRoom(ChatRoomDTO.Create request){
         return ChatRoom.createPrivateRoom(request.getName());

--- a/src/main/java/com/roomfit/be/chat/application/dto/ChatRoomDTO.java
+++ b/src/main/java/com/roomfit/be/chat/application/dto/ChatRoomDTO.java
@@ -15,10 +15,12 @@ public class ChatRoomDTO {
     public static class Response{
         Long id;
         String name;
+        String description;
         String type;
         String status;
         Integer maxQuota;
         Integer currentQuota;
+        String dormitory;
         public static Response of(ChatRoom chatRoom){
             return Response.builder()
                     .id(chatRoom.getId())
@@ -37,8 +39,10 @@ public class ChatRoomDTO {
     @AllArgsConstructor
     public static class Create{
         String name;
+        String description;
         String type;
         Integer maxQuota;
+        String dormitory;
     }
 
     @Data

--- a/src/main/java/com/roomfit/be/chat/domain/ChatRoom.java
+++ b/src/main/java/com/roomfit/be/chat/domain/ChatRoom.java
@@ -26,6 +26,8 @@ public class ChatRoom extends BaseEntity {
     Long id;
     String name;
 
+    String description;
+
     @Enumerated(EnumType.STRING)
     ChatRoomType type;
 
@@ -38,6 +40,8 @@ public class ChatRoom extends BaseEntity {
     @Builder.Default
     Integer currentQuota = DEFAULT_QUOTA;
 
+    String dormitory;
+
 
     @OneToMany()
     List<Participation> participationList;
@@ -49,11 +53,13 @@ public class ChatRoom extends BaseEntity {
                 .name(name)
                 .build();
     }
-    public static ChatRoom createGroupRoom(String name, Integer maxQuota){
+    public static ChatRoom createGroupRoom(String name, String description, String dormitory, Integer maxQuota){
         return ChatRoom.builder()
                 .type(ChatRoomType.GROUP)
                 .maxQuota(maxQuota)
                 .name(name)
+                .description(description)
+                .dormitory(dormitory)
                 .build();
     }
 }


### PR DESCRIPTION
## 🐛 연결 된 이슈
- #34 

## 내용
`description(설명)`, `dormitory(기숙사)` 필드를 추가하였고, domain 내에서 이를 저장할 때 null 허용을 하여 group 에서만 이를 사용하도록 구성하였습니다.

null 을 허용한 이유는 실제 mysql 내에서는 null 인 데이터는 직접적인 저장을 하지 않기 때문에, 데이터 자원을 아낄 수 있기 때문에 다음과 같은 구조를 선택했습니다.