### PR TITLE
기존 순환참조의 위험이 있는 구조를 Event Driven을 활용하여 느슨한 결합으로 처리

### DIFF
--- a/src/main/java/com/roomfit/be/chat/application/ChatRoomService.java
+++ b/src/main/java/com/roomfit/be/chat/application/ChatRoomService.java
@@ -9,7 +9,9 @@ import java.util.List;
 
 public interface ChatRoomService {
     ChatRoomDTO.Response createRoom(Long userId, ChatRoomDTO.Create request);
-    ChatRoomDTO.Response enterRoom(Long userId,Long roomId);
+    void enterRoom(Long userId,Long roomId);
     void leaveRoom(ChatRoomDTO.Leave request);
     List<MessageDTO.Response> readMessageByRoomId(Long roomId);
+
+    List<ChatRoomDTO.Response> readAllChatRooms(String type);
 }

--- a/src/main/java/com/roomfit/be/email/EmailSendEvent.java
+++ b/src/main/java/com/roomfit/be/email/EmailSendEvent.java
@@ -1,5 +1,0 @@
-package com.roomfit.be.email;
-
-public record EmailSendEvent(String recipient, String subject, String body) {
-}
-

--- a/src/main/java/com/roomfit/be/email/application/EmailSendEvent.java
+++ b/src/main/java/com/roomfit/be/email/application/EmailSendEvent.java
@@ -1,0 +1,23 @@
+package com.roomfit.be.email.application;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+
+@Getter
+public final class EmailSendEvent extends ApplicationEvent {
+    private final String recipient;
+    private final String subject;
+    private final String body;
+    private EmailSendEvent(Object source, String recipient, String subject, String body) {
+        super(source);
+        this.recipient = recipient;
+        this.subject = subject;
+        this.body = body;
+    }
+    public static EmailSendEvent of(Object source, String recipient, String subject, String body){
+        return new EmailSendEvent(source, recipient, subject, body);
+    }
+
+}
+

--- a/src/main/java/com/roomfit/be/email/application/EmailService.java
+++ b/src/main/java/com/roomfit/be/email/application/EmailService.java
@@ -1,4 +1,4 @@
-package com.roomfit.be.email;
+package com.roomfit.be.email.application;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;

--- a/src/main/java/com/roomfit/be/email/presentation/EmailEventListener.java
+++ b/src/main/java/com/roomfit/be/email/presentation/EmailEventListener.java
@@ -1,5 +1,7 @@
-package com.roomfit.be.email;
+package com.roomfit.be.email.presentation;
 
+import com.roomfit.be.email.application.EmailSendEvent;
+import com.roomfit.be.email.application.EmailService;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -16,6 +18,6 @@ public class EmailEventListener {
     @EventListener
     @Async("taskExecutor")
     public void onEmailSendEventHandler(EmailSendEvent event) throws MessagingException {
-        emailService.sendEmail(event.recipient(), event.subject(), event.body());
+        emailService.sendEmail(event.getRecipient(), event.getSubject(), event.getBody());
     }
 }

--- a/src/main/java/com/roomfit/be/global/event/EventPublisher.java
+++ b/src/main/java/com/roomfit/be/global/event/EventPublisher.java
@@ -1,0 +1,17 @@
+package com.roomfit.be.global.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EventPublisher {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void publish(ApplicationEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+
+}

--- a/src/main/java/com/roomfit/be/participation/application/ParticipationService.java
+++ b/src/main/java/com/roomfit/be/participation/application/ParticipationService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface ParticipationService {
     void joinAsHost(Long userId, Long chatRoomId);
-    ChatRoom joinAsParticipant(Long userId, Long chatRoomId);
+    void joinAsParticipant(Long userId, Long chatRoomId);
 //    void removeParticipant(Long userId, Long chatRoomId);
     List<User> readParticipantsByRoomId(Long roomId);
 }

--- a/src/main/java/com/roomfit/be/participation/application/ParticipationServiceImpl.java
+++ b/src/main/java/com/roomfit/be/participation/application/ParticipationServiceImpl.java
@@ -30,7 +30,7 @@ public class ParticipationServiceImpl implements  ParticipationService{
     }
 
     @Override
-    public ChatRoom joinAsParticipant(Long userId, Long chatRoomId) {
+    public void joinAsParticipant(Long userId, Long chatRoomId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
@@ -38,7 +38,6 @@ public class ParticipationServiceImpl implements  ParticipationService{
         
         Participation participation = Participation.participateAsParticipant(user, chatRoom);
         participationRepository.save(participation);
-        return chatRoom;
     }
 
     @Override

--- a/src/main/java/com/roomfit/be/participation/application/event/JoinAsHostEvent.java
+++ b/src/main/java/com/roomfit/be/participation/application/event/JoinAsHostEvent.java
@@ -1,0 +1,19 @@
+package com.roomfit.be.participation.application.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public final class JoinAsHostEvent extends ApplicationEvent {
+    private final Long userId;
+    private final Long chatRoomId;
+
+    private JoinAsHostEvent(Object source, Long userId, Long chatRoomId) {
+        super(source);
+        this.userId = userId;
+        this.chatRoomId = chatRoomId;
+    }
+    public static JoinAsHostEvent of(Object source,Long userId, Long chatRoomId){
+        return new JoinAsHostEvent(source, userId, chatRoomId);
+    }
+}

--- a/src/main/java/com/roomfit/be/participation/application/event/JoinAsParticipantEvent.java
+++ b/src/main/java/com/roomfit/be/participation/application/event/JoinAsParticipantEvent.java
@@ -1,0 +1,19 @@
+package com.roomfit.be.participation.application.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public final class JoinAsParticipantEvent extends ApplicationEvent {
+    private final Long userId;
+    private final Long chatRoomId;
+
+    private JoinAsParticipantEvent(Object source, Long userId, Long chatRoomId) {
+        super(source);
+        this.userId = userId;
+        this.chatRoomId = chatRoomId;
+    }
+    public static JoinAsParticipantEvent of(Object source,Long userId, Long chatRoomId){
+        return new JoinAsParticipantEvent(source, userId, chatRoomId);
+    }
+}

--- a/src/main/java/com/roomfit/be/participation/presentation/ParticipationEventListener.java
+++ b/src/main/java/com/roomfit/be/participation/presentation/ParticipationEventListener.java
@@ -1,0 +1,30 @@
+package com.roomfit.be.participation.presentation;
+
+import com.roomfit.be.participation.application.ParticipationService;
+import com.roomfit.be.participation.application.event.JoinAsHostEvent;
+import com.roomfit.be.participation.application.event.JoinAsParticipantEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * TODO: 추후 Retry 로직 추가 필요
+ */
+@Component
+@RequiredArgsConstructor
+public class ParticipationEventListener {
+    private final ParticipationService participationService;
+
+    @EventListener
+    @Async("taskExecutor")
+    public void onJoinAsHostHandler(JoinAsHostEvent event){
+        participationService.joinAsHost(event.getUserId(),  event.getChatRoomId());
+    }
+
+    @EventListener
+    @Async("taskExecutor")
+    public void onJoinAsParticipantHandler(JoinAsParticipantEvent event){
+        participationService.joinAsParticipant(event.getUserId(),  event.getChatRoomId());
+    }
+}


### PR DESCRIPTION
## 🐛연결 된 이슈
- #54 

## 📖 내용
- `EventPublisher`를 구성하여 도메인 간 상호작용을 이벤트 기반으로 처리하도록 변경
- `EmailSentEvent`를 `ApplicationEvent`를 상속하여 구현, 이메일 전송 완료 이벤트 처리
- `EmailEventListener`에서 이벤트 처리 방식을 변경하여 보다 효율적으로 이벤트를 처리
- `ParticipationEventListener` 구현, 참가 관련 이벤트를 처리하는 리스너 추가
- `JoinAsHostEvent`, `JoinAsParticipantEvent` 추가, `ApplicationEvent`를 상속받아 각각 호스트와 참가자의 참가 이벤트를 처리
- `ParticipationService`에서 이벤트 처리 방식에 맞게 `return` 타입을 `void`로 변경하여 이벤트 발행 후 처리를 최적화
- `ChatService`에서 직접적인 `participation` 주입 방식을 이벤트 발행 방식으로 변경, 서비스 간 결합도를 낮추고 확장성 개선